### PR TITLE
feat: #196 conexión de evaluación cliente con gestor documental

### DIFF
--- a/src/app/@core/utils/gestor-documental.service.ts
+++ b/src/app/@core/utils/gestor-documental.service.ts
@@ -1,0 +1,145 @@
+import { Injectable } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+import { Subject } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { RequestManager } from '../../managers/requestManager';
+import { DocumentoService } from '../data/documento.service';
+import { Documento } from '../data/models/documento';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GestorDocumentalService {
+
+  constructor(
+    private anyService: RequestManager,
+    private documentoService: DocumentoService,
+    private sanitization: DomSanitizer
+  ) { }
+
+  getUrlFile(base64, minetype) {
+    return new Promise<string>((resolve, reject) => {
+      const url = `data:${minetype};base64,${base64}`;
+      fetch(url)
+        .then(res => res.blob())
+        .then(blob => {
+          const file = new File([blob], "File name", { type: minetype })
+          const url = URL.createObjectURL(file);
+          resolve(url);
+        })
+    });
+  }
+
+  fileToBase64(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onload = () => {
+        let encoded = reader.result.toString().replace(/^data:(.*,)?/, '');
+        if ((encoded.length % 4) > 0) {
+          encoded += '='.repeat(4 - (encoded.length % 4));
+        }
+        resolve(encoded);
+      };
+      reader.onerror = error => reject(error);
+    });
+  }
+
+  uploadFiles(files) {
+    const documentsSubject = new Subject<Documento[]>();
+    const documents$ = documentsSubject.asObservable();
+    const documentos = [];
+    files.map(async (file) => {
+      const sendFileData = [{
+        IdTipoDocumento: file.IdDocumento,
+        nombre: file.nombre,
+        metadatos: file.metadatos ? file.metadatos : {},
+        descripcion: file.descripcion ? file.descripcion : "",
+        file: await this.fileToBase64(file.file)
+      }]
+      this.anyService.setPath('GESTOR_DOCUMENTAL_MID');
+      this.anyService.post('document/upload',sendFileData)
+        .subscribe((dataResponse) => {
+          documentos.push(dataResponse);
+          if (documentos.length === files.length) {
+            documentsSubject.next(documentos);
+          }
+        }, (error) => {
+          documentsSubject.error(error);
+        })
+    });
+    return documents$;
+  }
+
+  uploadFilesElectronicSign(files) {
+    const documentsSubject = new Subject<Documento[]>();
+    const documents$ = documentsSubject.asObservable();
+    const documentos = [];
+    files.map(async (file) => {
+      const sendFileDataandSigners = [{
+        IdTipoDocumento: file.IdDocumento,
+        nombre: file.nombre,
+        metadatos: file.metadatos ? file.metadatos : {},
+        descripcion: file.descripcion ? file.descripcion : "",
+        file: await this.fileToBase64(file.file),
+        firmantes: file.firmantes ? file.firmantes : [],
+        representantes: file.representantes ? file.representantes : []
+      }]
+      this.anyService.setPath('GESTOR_DOCUMENTAL_MID');
+      this.anyService.post('document/firma_electronica',sendFileDataandSigners)
+        .subscribe((dataResponse) => {
+          documentos.push(dataResponse);
+          if (documentos.length === files.length) {
+            documentsSubject.next(documentos);
+          }
+        }, (error) => {
+          documentsSubject.error(error);
+        })
+    });
+    return documents$
+  }
+
+  getFiles(files) {
+    const documentsSubject = new Subject<Documento[]>();
+    const documents$ = documentsSubject.asObservable();
+    const documentos = files;
+    let i = 0;
+    files.map((file, index) => {
+      this.documentoService.get('documento/'+file.id)
+        .subscribe((doc: Documento) => {
+          this.anyService.setPath('GESTOR_DOCUMENTAL_MID');
+          this.anyService.get('document/'+doc.Enlace)
+            .subscribe(async (f: any) => {
+              const url = await this.getUrlFile(f.file, f['file:content']['mime-type']);
+              documentos[index] = { ...documentos[index], ...{ url: url}, ...{ Documento: this.sanitization.bypassSecurityTrustUrl(url) } }
+              i += 1;
+              if (i === files.length) {
+                documentsSubject.next(documentos);
+              }
+            }, (error) => {
+              documentsSubject.error(error);
+            })
+        }, (error) => {
+          documentsSubject.error(error);
+        })
+    });
+    return documents$
+  }
+
+  getByUUID(uuid) {
+    const documentsSubject = new Subject<Documento[]>();
+    const documents$ = documentsSubject.asObservable();
+    let documento = null;
+    this.anyService.setPath('GESTOR_DOCUMENTAL_MID');
+    this.anyService.get('document/'+uuid)
+      .subscribe(async (f: any) => {
+        const url = await this.getUrlFile(f.file, f['file:content']['mime-type']);
+        documento = url
+        documentsSubject.next(documento);
+      }, (error) => {
+        documentsSubject.error(error);
+      })
+    return documents$;
+  }
+
+}

--- a/src/app/components/ver-certificacion/ver-certificacion.component.ts
+++ b/src/app/components/ver-certificacion/ver-certificacion.component.ts
@@ -19,6 +19,7 @@ import pdfFonts from "../../../assets/skins/lightgray/fonts/custom-fonts";
 import { EvaluacioncrudService } from "../../@core/data/evaluacioncrud.service";
 import Swal from "sweetalert2";
 import { Subscription } from "rxjs";
+import { GestorDocumentalService } from "../../@core/utils/gestor-documental.service";
 
 @Component({
   selector: "ngx-ver-certificacion",
@@ -51,6 +52,7 @@ export class VerCertificacionComponent implements OnInit {
 
   constructor(
     private nuxeoService: NuxeoService,
+    private gestorDocumental: GestorDocumentalService,
     private documentoService: DocumentoService,
     private evaluacionMidService: EvaluacionmidService,
     private windowService: NbWindowService,
@@ -195,19 +197,19 @@ export class VerCertificacionComponent implements OnInit {
       key: "prueba",
     };
 
-    
+    const serv = this.gestorDocumental.getByUUID(contrato.Enlace);
 
-    const serv = this.nuxeoService.getDocumentoOne$(
+    /* const serv = this.nuxeoService.getDocumentoOne$(
       anObject,
       this.documentoService
-    );
+    ); */
 
     (this.subscription = serv.subscribe((response) => {
       //console.log("respuesta 1", response);
 
       //console.log("respuesta", response["prueba"]);
 
-      this.download(response["prueba"], "", 1000, 1000);
+      this.download(response, "", 1000, 1000);
     })),
       (error_service) => {
         this.openWindow("No se pudo descargar la certificacion");

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -9,6 +9,7 @@ export const environment = {
   NUXEO: {
     PATH: 'https://documental.udistrital.edu.co/nuxeo/',
   },
+  GESTOR_DOCUMENTAL_MID: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/gestor_documental_mid/v1/',
   CONFIGURACION_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/configuracion_crud_api/v1/',
   // NOTIFICACION_SERVICE: 'ws://pruebasapi.intranetoas.udistrital.edu.co:8116/ws',
   CONF_MENU_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/configuracion_crud_api/v1/menu_opcion_padre/ArbolMenus/',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -14,6 +14,7 @@ export const environment = {
       PASS: 'desarrollooas2019',
     },
   },
+  GESTOR_DOCUMENTAL_MID: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/gestor_documental_mid/v1/',
   CONFIGURACION_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/configuracion_crud_api/v1/',
   // NOTIFICACION_SERVICE: 'ws://pruebasapi.intranetoas.udistrital.edu.co:8116/ws',
   CONF_MENU_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/configuracion_crud_api/v1/menu_opcion_padre/ArbolMenus/',

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -13,6 +13,7 @@ export const environment = {
       PASS: 'desarrollooas2019',
     },
   },
+  GESTOR_DOCUMENTAL_MID: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/gestor_documental_mid/v1/',
   CONFIGURACION_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/configuracion_crud_api/v1/',
   // NOTIFICACION_SERVICE: 'ws://pruebasapi.intranetoas.udistrital.edu.co:8116/ws',
   CONF_MENU_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/configuracion_crud_api/v1/menu_opcion_padre/ArbolMenus/',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -23,6 +23,7 @@ export const environment = {
       */
     },
   },
+  GESTOR_DOCUMENTAL_MID: 'http://pruebasapi2.intranetoas.udistrital.edu.co:8199/v1/',
   CONFIGURACION_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/configuracion_crud_api/v1/',
   // NOTIFICACION_SERVICE: 'ws://pruebasapi.intranetoas.udistrital.edu.co:8116/ws',
   CONF_MENU_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/configuracion_crud_api/v1/menu_opcion_padre/ArbolMenus/',


### PR DESCRIPTION
- #196 
- Creación de servicio para consumo de api gestor documental mid
	- se añade a los distintos ambientes la url para acceso a la api
	- el servicio cuenta con consulta por uid y documentoId, y carga de archivos tanto en version con firma electrónica y si firma.
	- integra conversión de archivos a base64 y sanitización para retornar url de archivo blob en cliente

### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
