### PR TITLE
feat: #207 uso firmaElectrónica cert Cumplimiento

### DIFF
--- a/src/app/@core/data/terceros.service.ts
+++ b/src/app/@core/data/terceros.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { RequestManager } from '../../managers/requestManager';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TercerosService {
+
+  constructor(private requestManager: RequestManager) {
+    this.requestManager.setPath('TERCEROS_SERVICE');
+  }
+
+  get(endpoint) {
+    this.requestManager.setPath('TERCEROS_SERVICE');
+    return this.requestManager.get(endpoint);
+  }
+
+  post(endpoint, element) {
+    this.requestManager.setPath('TERCEROS_SERVICE');
+    return this.requestManager.post(endpoint, element);
+  }
+
+  put(endpoint, element) {
+    this.requestManager.setPath('TERCEROS_SERVICE');
+    return this.requestManager.put(endpoint, element);
+  }
+
+  delete(endpoint, element) {
+    this.requestManager.setPath('TERCEROS_SERVICE');
+    return this.requestManager.delete(endpoint, element.Id);
+  }
+}

--- a/src/app/components/crear-certificacion/crear-certificacion.component.ts
+++ b/src/app/components/crear-certificacion/crear-certificacion.component.ts
@@ -25,7 +25,6 @@ import { THIS_EXPR } from '@angular/compiler/src/output/output_ast';
 import { throwToolbarMixedModesError } from '@angular/material';
 import { fontStyle } from 'html2canvas/dist/types/css/property-descriptors/font-style';
 import { GestorDocumentalService } from '../../@core/utils/gestor-documental.service';
-import { RequestManager } from '../../managers/requestManager';
 
 // Set the fonts to use
 
@@ -110,7 +109,6 @@ export class CrearCertificacionComponent implements OnInit {
     private NumerosAletrasService: NumerosAletrasService,
     private AdministrativaAmazon: AdministrativaamazonService,
     private NovedadesService: NovedadesService,
-    private anyService: RequestManager,
   ) {
     this.volverFiltro = new EventEmitter();
   }
@@ -128,7 +126,7 @@ export class CrearCertificacionComponent implements OnInit {
     var cadena1 =
       'Que de acuerdo con la información que reposa en la carpeta contractual y en las bases de ' +
       'datos que administra la Oficina Asesora Jurídica de la Universidad Distrital Francisco José de Caldas, ';
-    var cadena2 = ', identicado(a) con cédiula de ciudadanía No. ';
+    var cadena2 = ', identicado(a) con cédula de ciudadanía No. ';
     var cadena3 =
       ', suscribió en esta Entidad lo siguiente:';
     var date = new Date();
@@ -1399,8 +1397,8 @@ export class CrearCertificacionComponent implements OnInit {
           {
             text:
               textoDuracion +
-              ', contados a partir del acta de inicio, previo cumplimiento' +
-              'de los requisitos de perfeccionamiento y ejecución, sin superar' +
+              ', contados a partir del acta de inicio, previo cumplimiento ' +
+              'de los requisitos de perfeccionamiento y ejecución, sin superar ' +
               'el tiempo de la vigencia fiscal.',
             style: 'tabla2'
           }
@@ -1783,17 +1781,15 @@ export class CrearCertificacionComponent implements OnInit {
   }
 
   consultarFirmantes(){
-    let docSupervisor = "1085248305"
-    this.anyService.setPath('ADMINISTRATIVA_JBPM_SERVICE');
-    this.anyService.get('supervisor_contratistas/'+docSupervisor)
+    let IdCargoJuridica = 78;
+    this.AdministrativaAmazon.get('supervisor_contrato?query=CargoId__Id:'+IdCargoJuridica+'&sortby=FechaInicio&order=desc&limit=1')
       .subscribe((response) => {
-        if (Object.keys(response.supervisores).length > 0) {
-          let supervisor = response.supervisores.supervisor_contratista[0].supervisor;
+        if (Object.keys(response[0]).length > 0) {
           this.firmantes = {
-            nombre: supervisor.nombre,
-            tipoId: "cc",
-            identificacion: docSupervisor,
-            cargo: supervisor.cargo
+            nombre: response[0].Nombre,
+            tipoId: "CC",
+            identificacion: String(response[0].Documento),
+            cargo: response[0].Cargo
           }
         } else {
           this.firmantes = undefined;
@@ -1869,7 +1865,7 @@ export class CrearCertificacionComponent implements OnInit {
     ).subscribe(
       (data: any) => {
         this.allNovedades = data;
-        console.info(this.allNovedades);
+        //console.info(this.allNovedades);
         this.datosNovedades.push('Sin novedades');
         for (let i = 0; i < data.length; i++) {
           switch (data[i].tiponovedad) {

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -16,6 +16,7 @@ export const environment = {
   DOCUMENTO_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/documento_crud/v2/',
   NOVEDADES_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/novedades_mid/v1/',
   ADMINISTRATIVA_JBPM_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/administrativa_jbpm/v1/',
+  TERCEROS_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/terceros_crud/v1/',
 
   SPAGOBI: {
     PROTOCOL: 'https',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -16,6 +16,7 @@ export const environment = {
   DOCUMENTO_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/documento_crud/v2/',
   NOVEDADES_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/novedades_mid/v1/',
   ADMINISTRATIVA_JBPM_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/administrativa_jbpm/v1/',
+  TERCEROS_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/terceros_crud/v1/',
 
   SPAGOBI: {
     PROTOCOL: 'https',

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -16,6 +16,7 @@ export const environment = {
   DOCUMENTO_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/documento_crud/v2/',
   NOVEDADES_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/novedades_mid/v1/',
   ADMINISTRATIVA_JBPM_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/administrativa_jbpm/v1/',
+  TERCEROS_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/terceros_crud/v1/',
 
   SPAGOBI: {
     PROTOCOL: 'https',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -20,6 +20,7 @@ export const environment = {
   DOCUMENTO_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/documento_crud/v2/',
   NOVEDADES_SERVICE: 'http://pruebasapi.intranetoas.udistrital.edu.co:8502/v1/',
   ADMINISTRATIVA_JBPM_SERVICE: 'https://autenticacion.portaloas.udistrital.edu.co/apioas/administrativa_jbpm/v1/',
+  TERCEROS_SERVICE: 'http://pruebasapi.intranetoas.udistrital.edu.co:8121/v1/',
 
   SPAGOBI: {
     PROTOCOL: 'https',


### PR DESCRIPTION
- https://github.com/udistrital/evaluacion_cliente/issues/207
- Se usa administrativa_amazon para la consulta de jefe de dependecia actual:
   - jefe sección compras para cumplimiento
   - jefe de jurídica para contractual ya queda generalizado por cargo en vez de consultar por la persona.
- Para cert cumplimiento, quienes firman quedan de la siguiente manera:
   - firmantes: jefe seccón compras
   - representante: usuario loggeado (su info se consulta desde terceros)
- Teniendo la necesidad de usar terceros, se añade su respectivo servicio.
- Se ajustan pequeños detalles de escritura en cert contractual.

### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [ ] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [ ] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
